### PR TITLE
Navigate to project details after creation

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Project, RosterPerson } from "@/lib/storage";
@@ -17,6 +18,7 @@ import {
 export default function ProjectsPage() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [roster, setRoster] = useState<RosterPerson[]>([]);
+  const router = useRouter();
 
   useEffect(() => {
     setProjects(loadProjects());
@@ -29,7 +31,11 @@ export default function ProjectsPage() {
   }, [projects]);
 
   function addProject(): void {
-    setProjects((prev) => [createProject({ name: `Project ${prev.length + 1}` }), ...prev]);
+    const newProject = createProject({ name: `Project ${projects.length + 1}` });
+    const updated = [newProject, ...projects];
+    setProjects(updated);
+    saveProjects(updated);
+    router.push(`/projects/${newProject.id}`);
   }
 
   function removeProject(id: string): void {


### PR DESCRIPTION
## Summary
- Add `useRouter` and navigation logic to project list page to redirect after creating a project
- Save newly created project immediately and navigate to its detail page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any & React hook lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68afa24168bc8333bc283d11b83fa0c7