### PR TITLE
Add description and status fields to projects

### DIFF
--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -177,6 +177,24 @@ export default function ProjectDetailsPage() {
       {/* Project Inputs */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         <div className="space-y-1">
+          <div className="text-sm font-medium">Description</div>
+          <Input
+            value={project.description}
+            onChange={(e) =>
+              setProject({ ...project, description: e.target.value })
+            }
+          />
+        </div>
+
+        <div className="space-y-1">
+          <div className="text-sm font-medium">Status</div>
+          <Input
+            value={project.status}
+            onChange={(e) => setProject({ ...project, status: e.target.value })}
+          />
+        </div>
+
+        <div className="space-y-1">
           <div className="text-sm font-medium">Start month</div>
           <input
             type="month"

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -65,7 +65,7 @@ export default function ProjectsPage() {
       </div>
 
       <div className="grid grid-cols-12 gap-2 text-sm font-medium text-muted-foreground">
-        <div className="col-span-3">Name</div>
+        <div className="col-span-3">Name / Description / Status</div>
         <div className="col-span-2">Start</div>
         <div className="col-span-2 text-right">Revenue</div>
         <div className="col-span-2 text-right">All-in</div>
@@ -77,9 +77,18 @@ export default function ProjectsPage() {
         const totals = computeProjectTotals(p, roster);
         return (
           <div key={p.id} className="grid grid-cols-12 gap-2 items-center">
-            <Link href={`/projects/${p.id}`} className="col-span-3 underline underline-offset-2">
-              {p.name}
-            </Link>
+            <div className="col-span-3">
+              <Link
+                href={`/projects/${p.id}`}
+                className="underline underline-offset-2"
+              >
+                {p.name}
+              </Link>
+              <div className="text-xs text-muted-foreground truncate">
+                {p.description}
+              </div>
+              <div className="text-xs text-muted-foreground">{p.status}</div>
+            </div>
             <div className="col-span-2">{p.startMonthISO}</div>
             <div className="col-span-2 text-right">{currency(totals.revenue)}</div>
             <div className="col-span-2 text-right">{currency(totals.allIn)}</div>
@@ -90,10 +99,16 @@ export default function ProjectsPage() {
               <Link className="text-sm underline" href={`/projects/${p.id}`}>
                 Edit
               </Link>
-              <button className="text-sm underline" onClick={() => duplicateProject(p.id)}>
+              <button
+                className="text-sm underline"
+                onClick={() => duplicateProject(p.id)}
+              >
                 Duplicate
               </button>
-              <button className="text-sm text-red-600 underline" onClick={() => removeProject(p.id)}>
+              <button
+                className="text-sm text-red-600 underline"
+                onClick={() => removeProject(p.id)}
+              >
                 Delete
               </button>
             </div>

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -36,6 +36,8 @@ export interface MonthRow {
 export interface Project {
   id: string;
   name: string;
+  description: string;
+  status: string;
   overheadPerHour: number;   // $/hr
   targetMarginPct: number;   // 0..1
   startMonthISO: string;     // YYYY-MM
@@ -132,6 +134,8 @@ export function createProject(partial?: Partial<Project>): Project {
   const proj: Project = {
     id: uuid(),
     name: partial?.name ?? "New Project",
+    description: partial?.description ?? "",
+    status: partial?.status ?? "Active",
     overheadPerHour: partial?.overheadPerHour ?? 15,
     targetMarginPct: partial?.targetMarginPct ?? 0.35,
     startMonthISO: start,
@@ -153,7 +157,7 @@ export function createProject(partial?: Partial<Project>): Project {
 }
 
 export function upsertProject(p: Project, projects: Project[]): Project[] {
-  const stamped = { ...p, updatedAt: Date.now() };
+  const stamped: Project = { ...p, updatedAt: Date.now() };
   const idx = projects.findIndex((x) => x.id === p.id);
   if (idx === -1) return [stamped, ...projects];
   const next = [...projects];


### PR DESCRIPTION
## Summary
- extend Project model with description and status
- allow editing new fields and persist them
- show description and status on projects list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any; React Hook useMemo called conditionally)*

------
https://chatgpt.com/codex/tasks/task_b_68aface102c8833398a6a0228f8dd593